### PR TITLE
Fixed code to avoid compilation warning

### DIFF
--- a/development/src/GXDateTime.cpp
+++ b/development/src/GXDateTime.cpp
@@ -754,14 +754,15 @@ int CGXDateTime::ToFormatString(const char* pattern, std::string& value)
     }
     else
     {
-        ret = (int)strftime(buff, sizeof(buff), pattern, &m_Value);
-        if (ret != 0)
-        {
-            ret = 0;
-            value = buff;
-        }
-        else
-        {
+        if (pattern != NULL) {
+            ret = (int)strftime(buff, sizeof(buff), pattern, &m_Value);
+            if (ret != 0) {
+                ret = 0;
+                value = buff;
+            } else {
+                ret = DLMS_ERROR_CODE_INVALID_PARAMETER;
+            }
+        } else {
             ret = DLMS_ERROR_CODE_INVALID_PARAMETER;
         }
     }


### PR DESCRIPTION
Fixed code to avoid compilation -Werror=nonull warning in GCC 10.