### PR TITLE
Fix compilation warning

### DIFF
--- a/development/include/GXDLMSSettings.h
+++ b/development/include/GXDLMSSettings.h
@@ -35,6 +35,7 @@
 #ifndef GXDLMSSETTINGS_H
 #define GXDLMSSETTINGS_H
 
+#include <memory>
 #include "enums.h"
 #include "GXBytebuffer.h"
 #include "GXDLMSLimits.h"


### PR DESCRIPTION
```sh
gurux> In file included from src/../include/GXAPDU.h:42,
gurux>                  from src/GXAPDU.cpp:35:
gurux> src/../include/GXDLMSSettings.h:153:10: error: 'unique_ptr' in namespace 'std' does not name a template type
gurux>   153 |     std::unique_ptr<CGXPlcSettings> m_PlcSettings;
gurux>       |          ^~~~~~~~~~
gurux> src/../include/GXDLMSSettings.h:44:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
gurux>    43 | #include "GXCipher.h"
gurux>   +++ |+#include <memory>
gurux>    44 |
gurux> make: *** [makefile:64: obj/GXAPDU.o] Error 1
```