### PR TITLE
Fix compilation warning

### DIFF
--- a/development/src/GXStandardObisCodeCollection.cpp
+++ b/development/src/GXStandardObisCodeCollection.cpp
@@ -510,7 +510,7 @@ bool CGXStandardObisCodeCollection::EqualsMask(std::string& obisMask, std::strin
     unsigned char bytes[6];
     if (GetBytes(ln, bytes) != DLMS_ERROR_CODE_OK)
     {
-        return NULL;
+        return false;
     }
     std::vector< std::string > tmp = GXHelpers::Split(obisMask, '.');
     return EqualsObisCode(tmp, bytes);


### PR DESCRIPTION
```sh
> src/GXStandardObisCodeCollection.cpp: In static member function 'static bool CGXStandardObisCodeCollection::EqualsMask(std::string&, std::string&)':
> src/GXStandardObisCodeCollection.cpp:513:16: error: converting to 'bool' from 'std::nullptr_t' requires direct-initialization [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-fpermissive-fpermissive8;;]
>   513 |         return NULL;
>       |                ^~~~
```