### PR TITLE
Fix build with gcc14

### DIFF
--- a/development/include/GXBytebuffer.h
+++ b/development/include/GXBytebuffer.h
@@ -38,6 +38,7 @@
 #include <string>
 #include "errorcodes.h"
 #include "enums.h"
+#include <cstdint>
 
 const unsigned char VECTOR_CAPACITY = 50;
 class CGXByteBuffer


### PR DESCRIPTION
```
src/GXCipher.cpp:228:20: error: 'uint32_t' was not declared in this scope
  228 | int CGXCipher::Int(uint32_t* rk,
      |                    ^~~~~~~~
src/GXCipher.cpp:39:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   38 | #include "../include/GXHelpers.h"
  +++ |+#include <cstdint>
   39 |
```