### PR TITLE
Fix build with gcc14

### DIFF
--- a/development/src/GXDLMSValueEventArg.cpp
+++ b/development/src/GXDLMSValueEventArg.cpp
@@ -103,7 +103,9 @@ void CGXDLMSValueEventArg::Init(
     int selector)
 {
     m_Server = server;
-    m_Settings = &server->GetSettings();
+    if (server) {
+        m_Settings = &server->GetSettings();
+    }
     m_Handled = false;
     SetTarget(target);
     SetIndex(index);

--- a/development/src/GXHelpers.cpp
+++ b/development/src/GXHelpers.cpp
@@ -968,15 +968,18 @@ void GXHelpers::Replace(std::string& str, std::string oldString, std::string new
 
 std::string& GXHelpers::ltrim(std::string& s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-        std::not1(std::ptr_fun<int, int>(std::isspace))));
+    s.erase(s.begin(),
+        std::find_if(s.begin(), s.end(), [](int c)
+            {return !std::isspace(c);
+            }));
     return s;
 }
 
 std::string& GXHelpers::rtrim(std::string& s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(),
-        std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }).base(), s.end());
     return s;
 }
 
@@ -1050,7 +1053,7 @@ int GetUtfString(CGXByteBuffer& buff, CGXDataInfo& info, bool knownType, CGXDLMS
         buff.Get((unsigned char*)tmp, len);
         value.vt = DLMS_DATA_TYPE_STRING_UTF8;
         value.strVal.append(tmp, len);
-        delete tmp;
+        delete[] tmp;
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
         if (info.GetXml() != NULL)
         {
@@ -1210,11 +1213,11 @@ int GetString(CGXByteBuffer& buff, CGXDataInfo& info, bool knownType, CGXDLMSVar
         tmp[len] = '\0';
         if ((ret = buff.Get((unsigned char*)tmp, len)) != 0)
         {
-            delete tmp;
+            delete[] tmp;
             return ret;
         }
         value = tmp;
-        delete tmp;
+        delete[] tmp;
     }
     else
     {

--- a/development/src/GXStandardObisCodeCollection.cpp
+++ b/development/src/GXStandardObisCodeCollection.cpp
@@ -564,6 +564,9 @@ static const char* GetN1CDescription(std::string& str)
     case 49:
         tmp = "Density of air";
         break;
+    default:
+        tmp = "Unknown";
+        break;
     }
     return tmp;
 }


### PR DESCRIPTION
```sh
In file included from /usr/arm-linux-gnueabihf/include/c++/14/string:54,
                 from thirdparty/gurux/development/src/../include/GXStandardObisCode.h:37,
                 from thirdparty/gurux/development/src/../include/GXStandardObisCodeCollection.h:39,
                 from thirdparty/gurux/development/src/GXStandardObisCodeCollection.cpp:34:
In member function ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/arm-linux-gnueabihf/include/c++/14/bits/basic_string.h:829:28,
    inlined from ‘void CGXStandardObisCodeCollection::Find(unsigned char*, int, std::vector<CGXStandardObisCode*>&)’ at thirdparty/gurux/development/src/GXStandardObisCodeCollection.cpp:596:54:
/usr/arm-linux-gnueabihf/include/c++/14/bits/basic_string.h:1695:26: error: ‘tmp’ may be used uninitialized [-Werror=maybe-uninitialized]
 1695 |         return _M_replace(size_type(0), this->size(), __s,
      |                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1696 |                           traits_type::length(__s));
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~
thirdparty/gurux/development/src/GXStandardObisCodeCollection.cpp: In member function ‘void CGXStandardObisCodeCollection::Find(unsigned char*, int, std::vector<CGXStandardObisCode*>&)’:
thirdparty/gurux/development/src/GXStandardObisCodeCollection.cpp:540:17: note: ‘tmp’ was declared here
  540 |     const char* tmp;
      |                 ^~~
cc1plus: all warnings being treated as errors
```
```sh
thirdparty/gurux/development/src/GXHelpers.cpp: In static member function ‘static std::string& GXHelpers::ltrim(std::string&)’:
thirdparty/gurux/development/src/GXHelpers.cpp:972:41: error: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Werror=deprecated-declarations]
  972 |         std::not1(std::ptr_fun<int, int>(std::isspace))));
      |                   ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
In file included from /usr/arm-linux-gnueabihf/include/c++/14/string:49,
                 from /usr/arm-linux-gnueabihf/include/c++/14/bits/locale_classes.h:40,
                 from /usr/arm-linux-gnueabihf/include/c++/14/bits/ios_base.h:41,
                 from /usr/arm-linux-gnueabihf/include/c++/14/ios:44,
                 from /usr/arm-linux-gnueabihf/include/c++/14/istream:40,
                 from /usr/arm-linux-gnueabihf/include/c++/14/fstream:40,
                 from thirdparty/gurux/development/src/GXHelpers.cpp:35:
/usr/arm-linux-gnueabihf/include/c++/14/bits/stl_function.h:1123:5: note: declared here
 1123 |     ptr_fun(_Result (*__x)(_Arg))
      |     ^~~~~~~
thirdparty/gurux/development/src/GXHelpers.cpp:972:18: error: ‘constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = pointer_to_unary_function<int, int>]’ is deprecated: use 'std::not_fn' instead [-Werror=deprecated-declarations]
  972 |         std::not1(std::ptr_fun<int, int>(std::isspace))));
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/arm-linux-gnueabihf/include/c++/14/bits/stl_function.h:1043:5: note: declared here
 1043 |     not1(const _Predicate& __pred)
      |     ^~~~
thirdparty/gurux/development/src/GXHelpers.cpp: In static member function ‘static std::string& GXHelpers::rtrim(std::string&)’:
thirdparty/gurux/development/src/GXHelpers.cpp:979:41: error: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Werror=deprecated-declarations]
  979 |         std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
      |                   ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/usr/arm-linux-gnueabihf/include/c++/14/bits/stl_function.h:1123:5: note: declared here
 1123 |     ptr_fun(_Result (*__x)(_Arg))
      |     ^~~~~~~
thirdparty/gurux/development/src/GXHelpers.cpp:979:18: error: ‘constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = pointer_to_unary_function<int, int>]’ is deprecated: use 'std::not_fn' instead [-Werror=deprecated-declarations]
  979 |         std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/arm-linux-gnueabihf/include/c++/14/bits/stl_function.h:1043:5: note: declared here
 1043 |     not1(const _Predicate& __pred)
      |     ^~~~
```
```sh
thirdparty/gurux/development/src/GXHelpers.cpp: In function ‘int GetUtfString(CGXByteBuffer&, CGXDataInfo&, bool, CGXDLMSVariant&)’:
thirdparty/gurux/development/src/GXHelpers.cpp:1053:16: error: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
 1053 |         delete tmp;
      |                ^~~
thirdparty/gurux/development/src/GXHelpers.cpp:1049:27: note: returned from ‘void* operator new [](std::size_t)’
 1049 |         tmp = new char[len];
      |                           ^
thirdparty/gurux/development/src/GXHelpers.cpp: In function ‘int GetString(CGXByteBuffer&, CGXDataInfo&, bool, CGXDLMSVariant&)’:
thirdparty/gurux/development/src/GXHelpers.cpp:1213:20: error: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
 1213 |             delete tmp;
      |                    ^~~
thirdparty/gurux/development/src/GXHelpers.cpp:1205:31: note: returned from ‘void* operator new [](std::size_t)’
 1205 |         tmp = new char[len + 1];
      |                               ^
thirdparty/gurux/development/src/GXHelpers.cpp:1217:16: error: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
 1217 |         delete tmp;
      |                ^~~
thirdparty/gurux/development/src/GXHelpers.cpp:1205:31: note: returned from ‘void* operator new [](std::size_t)’
 1205 |         tmp = new char[len + 1];
      |                               ^
cc1plus: all warnings being treated as errors
```
```sh
In member function ‘void CGXDLMSValueEventArg::Init(CGXDLMSServer*, CGXDLMSObject*, int, int)’,
    inlined from ‘CGXDLMSValueEventArg::CGXDLMSValueEventArg(CGXDLMSObject*, int)’ at thirdparty/gurux/development/src/GXDLMSValueEventArg.cpp:142:9:
thirdparty/gurux/development/src/GXDLMSValueEventArg.cpp:106:38: error: ‘this’ pointer is null [-Werror=nonnull]
  106 |     m_Settings = &server->GetSettings();
      |                   ~~~~~~~~~~~~~~~~~~~^~
In file included from thirdparty/gurux/development/src/GXDLMSValueEventArg.cpp:37:
thirdparty/gurux/development/src/../include/GXDLMSServer.h: In constructor ‘CGXDLMSValueEventArg::CGXDLMSValueEventArg(CGXDLMSObject*, int)’:
thirdparty/gurux/development/src/../include/GXDLMSServer.h:209:22: note: in a call to non-static member function ‘CGXDLMSSettings& CGXDLMSServer::GetSettings()’
  209 |     CGXDLMSSettings& GetSettings();
      |                      ^~~~~~~~~~~
```