### PR TITLE
Fix build with gcc14

### DIFF
--- a/development/src/GXDLMSValueEventArg.cpp
+++ b/development/src/GXDLMSValueEventArg.cpp
@@ -103,7 +103,9 @@ void CGXDLMSValueEventArg::Init(
     int selector)
 {
     m_Server = server;
-    m_Settings = &server->GetSettings();
+    if (server) {
+        m_Settings = &server->GetSettings();
+    }
     m_Handled = false;
     SetTarget(target);
     SetIndex(index);


### PR DESCRIPTION
Rebase https://github.com/wirenboard/Gurux.DLMS.cpp/pull/6
```sh
In member function ‘void CGXDLMSValueEventArg::Init(CGXDLMSServer*, CGXDLMSObject*, int, int)’,
    inlined from ‘CGXDLMSValueEventArg::CGXDLMSValueEventArg(CGXDLMSObject*, int)’ at thirdparty/gurux/development/src/GXDLMSValueEventArg.cpp:142:9:
thirdparty/gurux/development/src/GXDLMSValueEventArg.cpp:106:38: error: ‘this’ pointer is null [-Werror=nonnull]
  106 |     m_Settings = &server->GetSettings();
      |                   ~~~~~~~~~~~~~~~~~~~^~
In file included from thirdparty/gurux/development/src/GXDLMSValueEventArg.cpp:37:
thirdparty/gurux/development/src/../include/GXDLMSServer.h: In constructor ‘CGXDLMSValueEventArg::CGXDLMSValueEventArg(CGXDLMSObject*, int)’:
thirdparty/gurux/development/src/../include/GXDLMSServer.h:209:22: note: in a call to non-static member function ‘CGXDLMSSettings& CGXDLMSServer::GetSettings()’
  209 |     CGXDLMSSettings& GetSettings();
      |                      ^~~~~~~~~~~
```