### PR TITLE
Fix build with -std=c++20

### DIFF
--- a/development/src/GXAPDU.cpp
+++ b/development/src/GXAPDU.cpp
@@ -49,13 +49,13 @@ int GetAuthenticationString(
         (!ignoreAcse && settings.GetCipher() != NULL && settings.GetCipher()->GetSecurity() != DLMS_SECURITY_NONE))
     {
         // Add sender ACSE-requirements field component.
-        data.SetUInt8(BER_TYPE_CONTEXT
-            | PDU_TYPE_SENDER_ACSE_REQUIREMENTS);
+        data.SetUInt8(static_cast<int>(BER_TYPE_CONTEXT)
+            | static_cast<int>(PDU_TYPE_SENDER_ACSE_REQUIREMENTS));
         data.SetUInt8(2);
         data.SetUInt8(BER_TYPE_BIT_STRING
             | BER_TYPE_OCTET_STRING);
         data.SetUInt8(0x80);
-        data.SetUInt8(BER_TYPE_CONTEXT | PDU_TYPE_MECHANISM_NAME);
+        data.SetUInt8(static_cast<int>(BER_TYPE_CONTEXT) | static_cast<int>(PDU_TYPE_MECHANISM_NAME));
         // Len
         data.SetUInt8(7);
         // OBJECT IDENTIFIER
@@ -99,7 +99,7 @@ int CGXAPDU::GenerateApplicationContextName(
     //ProtocolVersion
     if (settings.GetProtocolVersion() != NULL)
     {
-        data.SetUInt8(BER_TYPE_CONTEXT | PDU_TYPE_PROTOCOL_VERSION);
+        data.SetUInt8(static_cast<int>(BER_TYPE_CONTEXT) | static_cast<int>(PDU_TYPE_PROTOCOL_VERSION));
         data.SetUInt8(2);
         data.SetUInt8((unsigned char)(8 - strlen(settings.GetProtocolVersion())));
         CGXDLMSVariant tmp = settings.GetProtocolVersion();
@@ -1958,8 +1958,8 @@ int CGXAPDU::ParsePDU2(
 #endif //DLMS_IGNORE_XML_TRANSLATOR
             break;
             //  0x8A or 0x88
-        case BER_TYPE_CONTEXT | PDU_TYPE_SENDER_ACSE_REQUIREMENTS:
-        case BER_TYPE_CONTEXT | PDU_TYPE_CALLING_AP_INVOCATION_ID:
+        case static_cast<int>(BER_TYPE_CONTEXT) | static_cast<int>(PDU_TYPE_SENDER_ACSE_REQUIREMENTS):
+        case static_cast<int>(BER_TYPE_CONTEXT) | static_cast<int>(PDU_TYPE_CALLING_AP_INVOCATION_ID):
             // Get sender ACSE-requirements field component.
             if ((ret = buff.GetUInt8(&len)) != 0)
             {
@@ -1992,8 +1992,8 @@ int CGXAPDU::ParsePDU2(
 #endif //DLMS_IGNORE_XML_TRANSLATOR
             break;
             //  0x8B or 0x89
-        case BER_TYPE_CONTEXT | PDU_TYPE_MECHANISM_NAME:
-        case BER_TYPE_CONTEXT | PDU_TYPE_CALLING_AE_INVOCATION_ID:
+        case static_cast<int>(BER_TYPE_CONTEXT) | static_cast<int>(PDU_TYPE_MECHANISM_NAME):
+        case static_cast<int>(BER_TYPE_CONTEXT) | static_cast<int>(PDU_TYPE_CALLING_AE_INVOCATION_ID):
             if ((ret = UpdateAuthentication(settings, buff)) != 0)
             {
                 return ret;

--- a/development/src/GXCipher.cpp
+++ b/development/src/GXCipher.cpp
@@ -610,7 +610,7 @@ int CGXCipher::Encrypt(
     {
         input.Move(input.m_Position, offset, input.Available());
         input.m_Position = 0;
-        input.SetUInt8(0, security | suite);
+        input.SetUInt8(0, static_cast<int>(security) | static_cast<int>(suite));
         memcpy(input.m_Data + 1, m_AuthenticationKey.m_Data, m_AuthenticationKey.GetSize());
         AesGcmGhash(H, input.m_Data, input.m_Size, input.m_Data, 0, S);
         if (type == DLMS_COUNT_TYPE_TAG)
@@ -649,7 +649,7 @@ int CGXCipher::Encrypt(
         //Count authentication.
         input.Move(input.m_Position, offset, input.Available());
         input.m_Position = 0;
-        input.SetUInt8(0, security | suite);
+        input.SetUInt8(0, static_cast<int>(security) | static_cast<int>(suite));
         memcpy(input.m_Data + 1, m_AuthenticationKey.m_Data, m_AuthenticationKey.GetSize());
         AesGcmGhash(H, input.m_Data, offset, input.m_Data + offset, input.m_Size - offset, S);
         input.Move(offset, 0, input.m_Size - offset);
@@ -688,7 +688,7 @@ int CGXCipher::Encrypt(
                 nonse.Set(systemTitle.GetData(), 8);
             }
             GXHelpers::SetObjectCount(5 + input.GetSize(), nonse);
-            if ((ret = nonse.SetUInt8(security | suite)) == 0 &&
+            if ((ret = nonse.SetUInt8(static_cast<int>(security) | static_cast<int>(suite))) == 0 &&
                 (ret = nonse.SetUInt32(frameCounter)) == 0)
             {
                 input.Move(0, nonse.GetSize(), input.GetSize());

--- a/development/src/GXSecure.cpp
+++ b/development/src/GXSecure.cpp
@@ -237,7 +237,7 @@ int CGXSecure::Secure(
             DLMS_COUNT_TYPE_TAG, ic, 0, secret, key, data, true);
         if (ret == 0)
         {
-            reply.SetUInt8(DLMS_SECURITY_AUTHENTICATION | cipher->GetSecuritySuite());
+            reply.SetUInt8(static_cast<int>(DLMS_SECURITY_AUTHENTICATION) | static_cast<int>(cipher->GetSecuritySuite()));
             reply.SetUInt32(ic);
             reply.Set(&data);
         }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Fix C++20 compatibility:
```sh
error: bitwise operation between different enumeration types ‘DLMS_SECURITY’ and ‘DLMS_SECURITY_SUITE’ is deprecated [-Werror=deprecated-enum-enum-conversion]
```

___________________________________
**Что поменялось для пользователей:**
nothing

___________________________________
**Как проверял/а:**
wb-mqtt-serial + trixie

